### PR TITLE
Adjust the output of benign websites

### DIFF
--- a/logo_matching.py
+++ b/logo_matching.py
@@ -24,6 +24,7 @@ def check_domain_brand_inconsistency(logo_boxes,
     print('number of logo boxes:', len(logo_boxes))
     extracted_domain = tldextract.extract(url).domain + '.' + tldextract.extract(url).suffix
     matched_target, matched_domain, matched_coord, this_conf = None, None, None, None
+    benign_flag = False
 
     if len(logo_boxes) > 0:
         # siamese prediction for logo box
@@ -45,11 +46,12 @@ def check_domain_brand_inconsistency(logo_boxes,
                 matched_coord = coord
                 # Check if the domain is part of any domain listed under the brand
                 if extracted_domain in matched_domain:
-                    matched_target, matched_domain = None, None  # Clear if domains are consistent
+                    # matched_target, matched_domain = None, None  # we don't clear if domains are consistent now, instead, set the benign_flag = True
+                    benign_flag = True
                 else:
                     break  # Inconsistent domain found, break the loop
 
-    return brand_converter(matched_target), matched_domain, matched_coord, this_conf
+    return brand_converter(matched_target), matched_domain, matched_coord, this_conf, benign_flag
 
 
 def load_model_weights(num_classes: int, weights_path: str):

--- a/phishpedia.py
+++ b/phishpedia.py
@@ -120,7 +120,7 @@ class PhishpediaWrapper:
         # return phish_category, pred_target, matched_domain, plotvis, siamese_conf, pred_boxes, logo_recog_time, logo_match_time
         # else:
         print('Match to Target: {} with confidence {:.4f}'.format(pred_target, siamese_conf))
-        phish_category = 1 if benign_flag==False else 0
+        phish_category = 1 if benign_flag == False else 0
         # Visualize, add annotations
         cv2.putText(plotvis, "Target: {} with confidence {:.4f}".format(pred_target, siamese_conf),
                     (int(matched_coord[0] + 20), int(matched_coord[1] + 20)),

--- a/phishpedia.py
+++ b/phishpedia.py
@@ -97,7 +97,7 @@ class PhishpediaWrapper:
 
         ######################## Step2: Siamese (Logo matcher) ########################################
         start_time = time.time()
-        pred_target, matched_domain, matched_coord, siamese_conf = check_domain_brand_inconsistency(
+        pred_target, matched_domain, matched_coord, siamese_conf, benign_flag = check_domain_brand_inconsistency(
             logo_boxes=pred_boxes,
             domain_map_path=self.DOMAIN_MAP_PATH,
             model=self.SIAMESE_MODEL,
@@ -120,7 +120,7 @@ class PhishpediaWrapper:
         # return phish_category, pred_target, matched_domain, plotvis, siamese_conf, pred_boxes, logo_recog_time, logo_match_time
         # else:
         print('Match to Target: {} with confidence {:.4f}'.format(pred_target, siamese_conf))
-        phish_category = 1
+        phish_category = 1 if benign_flag==False else 0
         # Visualize, add annotations
         cv2.putText(plotvis, "Target: {} with confidence {:.4f}".format(pred_target, siamese_conf),
                     (int(matched_coord[0] + 20), int(matched_coord[1] + 20)),

--- a/phishpedia.py
+++ b/phishpedia.py
@@ -120,7 +120,7 @@ class PhishpediaWrapper:
         # return phish_category, pred_target, matched_domain, plotvis, siamese_conf, pred_boxes, logo_recog_time, logo_match_time
         # else:
         print('Match to Target: {} with confidence {:.4f}'.format(pred_target, siamese_conf))
-        phish_category = 1 if benign_flag == False else 0
+        phish_category = 1 if benign_flag is False else 0
         # Visualize, add annotations
         cv2.putText(plotvis, "Target: {} with confidence {:.4f}".format(pred_target, siamese_conf),
                     (int(matched_coord[0] + 20), int(matched_coord[1] + 20)),


### PR DESCRIPTION
For a benign website matched to any target brand with consistent domain, the previous implementation set the "matched_target" and "matched_domain" to None and finally output "Did not match to any brand, report as benign", which may lead to some confusion.
We slightly changed the output logic. As below, the matched target of a benign website (with correct url) will also be shown, but the label is still "0"(benign).

![result](https://github.com/user-attachments/assets/0f7ef85a-6451-472d-8d4c-27f1a38810bf)
